### PR TITLE
Broken check fix

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -59,7 +59,8 @@ CreateThread(function()
 	if Config.Framework == 'ESX' then
 		local ESX = exports['es_extended']:getSharedObject()
 
-		if GetResourceState('ox_inventory') ~= 'unknown' then
+        local resState = GetResourceState('ox_inventory')
+        if resState ~= 'missing' and resState ~= 'unknown' then
 			ItemCount = function(item)
 				return exports.ox_inventory:Search(2, item)
 			end


### PR DESCRIPTION
This change fixes a check that breaks `ItemCount()` (thus `CheckOptions()` when `data.item` is not nil) if you use es_extended but don't use ox_inventory.