### PR TITLE
Prevent kicking player if having weapon

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -183,6 +183,7 @@ local function EnableTarget()
 				DisablePlayerFiring(playerId, true)
 				DisableControlAction(0, 25, true)
 				DisableControlAction(0, 37, true)
+				DisableControlAction(0, 142, true)
 				Wait(0)
 			until targetActive == false
 		end)


### PR DESCRIPTION
If you are very close to another player, and enable the target while having a gun in your hands, pressing LMB will kick & kill the player. This is the fix

![image](https://user-images.githubusercontent.com/47056777/148634395-2dfd5fcf-8551-4864-8766-bcfbfa75f178.png)
